### PR TITLE
feat: update permalink to point to new site path for combo page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- Update permalink in combo result to point to new site's path
+
 # 0.11.0
 
 - Add `autocomplete` method

--- a/src/spellbook-api.ts
+++ b/src/spellbook-api.ts
@@ -48,7 +48,7 @@ function formatApiResponse(
 
       return {
         commanderSpellbookId: id,
-        permalink: `https://commanderspellbook.com/?id=${id}`,
+        permalink: `https://commanderspellbook.com/combo/${id}`,
         cards,
         colorIdentity,
         prerequisites,

--- a/test/unit/spellbook-api.test.ts
+++ b/test/unit/spellbook-api.test.ts
@@ -163,7 +163,7 @@ describe("api", () => {
     expect(combos[0]).toEqual(
       expect.objectContaining({
         commanderSpellbookId: "1",
-        permalink: "https://commanderspellbook.com/?id=1",
+        permalink: "https://commanderspellbook.com/combo/1",
         hasBannedCard: false,
         hasSpoiledCard: false,
       })
@@ -179,7 +179,7 @@ describe("api", () => {
     expect(combos[1]).toEqual(
       expect.objectContaining({
         commanderSpellbookId: "2",
-        permalink: "https://commanderspellbook.com/?id=2",
+        permalink: "https://commanderspellbook.com/combo/2",
         hasBannedCard: true,
         hasSpoiledCard: false,
       })
@@ -196,7 +196,7 @@ describe("api", () => {
     expect(combos[2]).toEqual(
       expect.objectContaining({
         commanderSpellbookId: "3",
-        permalink: "https://commanderspellbook.com/?id=3",
+        permalink: "https://commanderspellbook.com/combo/3",
         hasBannedCard: false,
         hasSpoiledCard: true,
       })


### PR DESCRIPTION
This should not be merged in until the new site is actually ready to release.